### PR TITLE
Fix you can not use os here

### DIFF
--- a/lib/validation_hook.rb
+++ b/lib/validation_hook.rb
@@ -1,7 +1,7 @@
 class JavascriptValidationHook < Mumukit::Hook
   def validate!(request)
     matches = request_matches?(request) do |it|
-      it =~ /(^|\W+)(require|process|os|fs|eval|cluster|v8|vm|tty|tls|root|global|crypto|stream|events)(\W+|$)/
+      it =~ /(^|[^[[:alnum:]]]+)(require|process|os|fs|eval|cluster|v8|vm|tty|tls|root|global|crypto|stream|events)([^[[:alnum:]]]+|$)/
     end
     raise Mumukit::RequestValidationError, "You can not use #{$2} here" if matches
   end

--- a/lib/validation_hook.rb
+++ b/lib/validation_hook.rb
@@ -1,7 +1,7 @@
 class JavascriptValidationHook < Mumukit::Hook
   def validate!(request)
     matches = request_matches?(request) do |it|
-      it =~ /(^|[^[[:alnum:]]]+)(require|process|os|fs|eval|cluster|v8|vm|tty|tls|root|global|crypto|stream|events)([^[[:alnum:]]]+|$)/
+      it =~ /(^|[^_[[:alnum:]]]+)(require|process|os|fs|eval|cluster|v8|vm|tty|tls|root|global|crypto|stream|events)([^_[[:alnum:]]]+|$)/
     end
     raise Mumukit::RequestValidationError, "You can not use #{$2} here" if matches
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -162,4 +162,67 @@ javascript
                            expectation_results: [],
                            result: '')
   end
+
+  it 'ñ' do
+    response = bridge.run_tests!(
+      test: %q{
+      describe("", function() {
+        let juan = {
+          nombre: "Juan Arrever",
+          librosLeidos: ["El conde de Montecristo", "La palabra", "Mi planta de naranja lima"],
+          anioSuscripcion: 1992
+        };
+
+        let elena = {
+          nombre: "Elena Chalver",
+          librosLeidos: ["Rabia", "Vida de Bob Marley"],
+          anioSuscripcion: 1987
+        };
+
+        let gustavo = {
+          nombre: "Gustavo Girot",
+          librosLeidos: ["Fundación", "Yo, Robot", "El resplandor", "Socorro"],
+          anioSuscripcion: 2010
+        };
+
+        it("el resumenLector de gustavo nos provee su información", function() {
+          assert.equal(resumenLector(gustavo), "Gustavo Girot se suscribió hace 10 anios y leyó 4 libros.")
+        })
+
+        it("el resumenLector de juan nos provee su información", function() {
+          assert.equal(resumenLector(juan), "Juan Arrever se suscribió hace 28 anios y leyó 3 libros.")
+        })
+
+        it("el resumenLector de elena nos provee su información", function() {
+          assert.equal(resumenLector(elena), "Elena Chalver se suscribió hace 33 anios y leyó 2 libros.")
+        })
+      })
+    },
+    extra: %q{
+    function longitud(unStringOLista) /*<elipsis-for-student@*/ {
+      return unStringOLista.length;
+    } /*@elipsis-for-student>*/
+    // Retorna el largo de un string o una lista
+    //
+    // Por ejemplo:
+    //
+    //  ム longitud("hola")
+    //  4
+    //  ム longitud([5, 6, 3])
+    //  3
+    },
+    content: %q{
+    function resumenLector(quien) {
+      "año"
+      return quien.nombre + " se suscribió hace " + (2020 - quien.anioSuscripcion)  + " años y leyó "+ quien.librosLeidos.length +" libros."
+    }},
+    expectations: [])
+
+    expect(response).to eq(response_type: :structured,
+                           test_results: [{title: 'foo bar', status: :passed, result: ''}],
+                           status: :passed,
+                           feedback: '',
+                           expectation_results: [],
+                           result: '')
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -163,22 +163,10 @@ javascript
                            result: '')
   end
 
-  it 'ñ' do
+  it 'answers a valid hash when submission passes and has non-ascii chars' do
     response = bridge.run_tests!(
       test: %q{
       describe("", function() {
-        let juan = {
-          nombre: "Juan Arrever",
-          librosLeidos: ["El conde de Montecristo", "La palabra", "Mi planta de naranja lima"],
-          anioSuscripcion: 1992
-        };
-
-        let elena = {
-          nombre: "Elena Chalver",
-          librosLeidos: ["Rabia", "Vida de Bob Marley"],
-          anioSuscripcion: 1987
-        };
-
         let gustavo = {
           nombre: "Gustavo Girot",
           librosLeidos: ["Fundación", "Yo, Robot", "El resplandor", "Socorro"],
@@ -186,40 +174,19 @@ javascript
         };
 
         it("el resumenLector de gustavo nos provee su información", function() {
-          assert.equal(resumenLector(gustavo), "Gustavo Girot se suscribió hace 10 anios y leyó 4 libros.")
-        })
-
-        it("el resumenLector de juan nos provee su información", function() {
-          assert.equal(resumenLector(juan), "Juan Arrever se suscribió hace 28 anios y leyó 3 libros.")
-        })
-
-        it("el resumenLector de elena nos provee su información", function() {
-          assert.equal(resumenLector(elena), "Elena Chalver se suscribió hace 33 anios y leyó 2 libros.")
+          assert.equal(resumenLector(gustavo), "Gustavo Girot se suscribió hace 10 años")
         })
       })
     },
-    extra: %q{
-    function longitud(unStringOLista) /*<elipsis-for-student@*/ {
-      return unStringOLista.length;
-    } /*@elipsis-for-student>*/
-    // Retorna el largo de un string o una lista
-    //
-    // Por ejemplo:
-    //
-    //  ム longitud("hola")
-    //  4
-    //  ム longitud([5, 6, 3])
-    //  3
-    },
+    extra: '',
     content: %q{
     function resumenLector(quien) {
-      "año"
-      return quien.nombre + " se suscribió hace " + (2020 - quien.anioSuscripcion)  + " años y leyó "+ quien.librosLeidos.length +" libros."
+      return quien.nombre + " se suscribió hace " + (2020 - quien.anioSuscripcion)  + " años";
     }},
     expectations: [])
 
     expect(response).to eq(response_type: :structured,
-                           test_results: [{title: 'foo bar', status: :passed, result: ''}],
+                           test_results: [{result: "", status: :passed, title: " el resumenLector de gustavo nos provee su información"}],
                            status: :passed,
                            feedback: '',
                            expectation_results: [],

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -20,5 +20,6 @@ describe JavascriptValidationHook do
   it { expect(hook.validate! struct(query: 'aProcess')).to be nil }
 
   it { expect(hook.validate! struct(extra: 'var pesoPromedioPersonaEnKilogramos = 75;')).to be nil }
+  it { expect(hook.validate! struct(extra: 'var _os_ = 75;')).to be nil }
 
 end


### PR DESCRIPTION
# :dart: Goal

To fix aborted error with some exercises that use the `años` word. 

# :memo: Details

This was just a general issue with a bad regexp that was not unicode-friendly 