### PR TITLE
Feature improve error message on compilation errors

### DIFF
--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -31,6 +31,10 @@ javascript
     transform(super['tests'])
   end
 
+  def cleanup_raw_result(result)
+    super.gsub(/(SyntaxError: .*\n)(.|\n)*/) { $1 }
+  end
+
   def transform(examples)
     examples.map { |e| [e['fullTitle'], e['err'].present? ? :failed : :passed, parse_out(e['err'])] }
   end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -44,7 +44,7 @@ javascript
 
   def post_process_unstructured_result(file, result, status)
     if status.errored?
-      [Mumukit::ContentType::Markdown.code(result.gsub(/(SyntaxError: .*\n)(.|\n)*/) { $1 }), status]
+      [content_type.code(result.gsub(/(SyntaxError: .*\n)(.|\n)*/) { $1 }), status]
     else
       super
     end
@@ -55,6 +55,6 @@ javascript
   end
 
   def parse_out(exception)
-    exception.present? ? Mumukit::ContentType::Markdown.code(exception['message']) : ''
+    exception.present? ? content_type.code(exception['message']) : ''
   end
 end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -19,17 +19,6 @@ describe('', function() {
 javascript
   end
 
-  def post_process_file(file, result, status)
-    result = extract_result(result)
-    if [:passed, :failed].include? status
-      [to_structured_result(result)]
-    else
-      post_process_unstructured_result(file, result, status)
-    end
-  rescue JSON::ParserError
-    post_process_unstructured_result(file, result, :errored)
-  end
-
   def tempfile_extension
     '.js'
   end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -1,13 +1,12 @@
 class JavascriptTestHook < Mumukit::Templates::FileHook
   isolated true
   structured true, separator: '!!!JAVASCRIPT-MUMUKI-OUTPUT!!!'
+  line_number_offset 3, include_extra: true
 
   def compile_file_content(request)
 <<javascript
 'use strict';
-
 let assert = require('assert');
-
 #{request.extra}
 #{request.content}
 describe('', function() {

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -44,7 +44,7 @@ javascript
 
   def post_process_unstructured_result(file, result, status)
     if status.errored?
-      [result.gsub(/(SyntaxError: .*\n)(.|\n)*/) { $1 }, status]
+      [Mumukit::ContentType::Markdown.code(result.gsub(/(SyntaxError: .*\n)(.|\n)*/) { $1 }), status]
     else
       super
     end

--- a/mumuki-javascript-runner.gemspec
+++ b/mumuki-javascript-runner.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'mumukit', '~> 2.38'
+  spec.add_dependency 'mumukit', '~> 2.40'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
@@ -25,6 +25,3 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'mumukit-bridge', '~> 3.5'
 end
-
-
-

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -64,11 +64,16 @@ javascript
         it { expect(status).to eq :errored }
         it { expect(results).to eq(
         <<EOF
+
+```
 solution.js:2
   reurn 4 + 5
         ^
 
 SyntaxError: Unexpected number
+
+```
+
 EOF
         ) }
       end
@@ -93,11 +98,16 @@ javascript
         it { expect(status).to eq :errored }
         it { expect(results).to eq(
         <<EOF
+
+```
 solution.js:2
   return 4 + 5
   ^^^^^^
 
 SyntaxError: Unexpected token return
+
+```
+
 EOF
         ) }
       end
@@ -122,11 +132,16 @@ javascript
         it { expect(status).to eq :errored }
         it { expect(results).to eq(
         <<EOF
+
+```
 solution.js:1
 funcion helloWorld() {
         ^^^^^^^^^^
 
 SyntaxError: Unexpected identifier
+
+```
+
 EOF
         ) }
       end
@@ -151,11 +166,16 @@ javascript
         it { expect(status).to eq :errored }
         it { expect(results).to eq(
         <<EOF
+
+```
 solution.js:16
 });
  ^
 
 SyntaxError: Unexpected token )
+
+```
+
 EOF
         ) }
       end


### PR DESCRIPTION
# :dart: Goal

To fix line numbers and remove a lot of clutter from error messages. 

# :test_tube: Testing

## :arrow_backward: Before

![Screenshot from 2021-02-10 14-10-47](https://user-images.githubusercontent.com/677436/107545326-eaed5700-6ba9-11eb-8a0e-a739ba5ae6c9.png)


## :arrow_forward: After

![Screenshot from 2021-02-10 14-08-15](https://user-images.githubusercontent.com/677436/107545216-ce511f00-6ba9-11eb-996b-71f32eb6ae3b.png)

# :warning: Dependencies 

* Depends on https://github.com/mumuki/mumukit/pull/111