### PR TITLE
Fix include result when query errors too

### DIFF
--- a/lib/try_hook.rb
+++ b/lib/try_hook.rb
@@ -29,15 +29,12 @@ js
   end
 
   def to_structured_results(_file, result, status)
-    /#{query_separator}
-?(.*)
-#{goal_separator}
-?(.*)
-/m =~ result
+    query_result = result[/#{query_separator}\n\K.*?(?=\n#{goal_separator}|\z)/m]
+    goal = result[/#{goal_separator}\n\K.*(?=\n)/m]
 
     {
-        query: to_query_result($1, status),
-        goal: $2,
+        query: to_query_result(query_result, status),
+        goal: goal,
         status: status
     }
   end

--- a/spec/expectations_spec.rb
+++ b/spec/expectations_spec.rb
@@ -13,7 +13,7 @@ describe JavascriptExpectationsHook do
   let(:result) { compile_and_run(req(expectations, code)) }
 
   describe 'HasTooShortIdentifiers' do
-    let(:code) { "function f(x) { retun g(x); }" }
+    let(:code) { "function f(x) { return g(x); }" }
     let(:expectations) { [] }
 
     it { expect(result).to eq [{expectation: {binding: 'f', inspection: 'HasTooShortIdentifiers'}, result: false}] }

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -7,9 +7,10 @@ describe JavascriptTryHook do
   let(:result) { hook.run!(file) }
 
   let(:goal) { { kind: 'query_outputs', query: '"goal :)"', output: '"goal :)"' } }
+  let(:request) { struct query: query, goal: goal }
 
   context 'with a dummy goal' do
-    let(:request) { struct query: '"asd"', goal: goal }
+    let(:query) { '"asd"' }
     it { expect(result[2][:result]).to eq '"asd"' }
     it { expect(result[1]).to eq :passed }
   end
@@ -18,12 +19,12 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'last_query_equals', value: '"something"' } }
 
     context 'and query that matches' do
-      let(:request) { struct query: '"something"', goal: goal }
+      let(:query) { '"something"' }
       it { expect(result[1]).to eq :passed }
     end
 
     context 'and query that does not match' do
-      let(:request) { struct query: '"somethingElse"', goal: goal }
+      let(:query) { '"somethingElse"' }
       it { expect(result[1]).to eq :failed }
     end
   end
@@ -32,12 +33,12 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'last_query_matches', regexp: /console\.log(.*)/ } }
 
     context 'and query that matches' do
-      let(:request) { struct query: 'console.log("hola")', goal: goal }
+      let(:query) { 'console.log("hola")' }
       it { expect(result[1]).to eq :passed }
     end
 
     context 'and query that does not match' do
-      let(:request) { struct query: 'var a = 2', goal: goal }
+      let(:query) { 'var a = 2' }
       it { expect(result[1]).to eq :failed }
     end
   end
@@ -46,12 +47,12 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'last_query_outputs', output: '3' } }
 
     context 'and query with said output' do
-      let(:request) { struct query: '1 + 2', goal: goal }
+      let(:query) { '1 + 2' }
       it { expect(result[1]).to eq :passed }
     end
 
     context 'and query with a different output' do
-      let(:request) { struct query: '5', goal: goal }
+      let(:query) { '5' }
       it { expect(result[1]).to eq :failed }
     end
   end
@@ -60,12 +61,12 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'query_fails', query: 'asd' } }
 
     context 'and query that makes said query pass' do
-      let(:request) { struct query: 'let asd = 2;', goal: goal }
+      let(:query) { 'let asd = 2;' }
       it { expect(result[1]).to eq :failed }
     end
 
     context 'and query that does not make said query pass' do
-      let(:request) { struct query: '', goal: goal }
+      let(:query) { '' }
       it { expect(result[1]).to eq :passed }
     end
   end
@@ -74,12 +75,12 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'query_passes', query: 'asd' } }
 
     context 'and query that makes said query pass' do
-      let(:request) { struct query: 'let asd = 2;', goal: goal }
+      let(:query) { 'let asd = 2;' }
       it { expect(result[1]).to eq :passed }
     end
 
     context 'nd query that does not make said query pass' do
-      let(:request) { struct query: '', goal: goal }
+      let(:query) { '' }
       it { expect(result[1]).to eq :failed }
     end
   end
@@ -88,12 +89,12 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'query_outputs', query: 'asd', output: '55' } }
 
     context 'and query that generates said output' do
-      let(:request) { struct query: 'let asd = 55;', goal: goal }
+      let(:query) { 'let asd = 55;' }
       it { expect(result[1]).to eq :passed }
     end
 
     context 'and query that does not generate said output' do
-      let(:request) { struct query: 'let asd = 28', goal: goal }
+      let(:query) { 'let asd = 28' }
       it { expect(result[1]).to eq :failed }
     end
   end
@@ -102,13 +103,20 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'last_query_passes' } }
 
     context 'and query that passes' do
-      let(:request) { struct query: '123', goal: goal }
+      let(:query) { '123' }
       it { expect(result[1]).to eq :passed }
     end
 
     context 'and query that fails' do
-      let(:request) { struct query: 'asdasd', goal: goal }
+      let(:query) { 'asdasd' }
       it { expect(result[1]).to eq :failed }
     end
+  end
+
+  context 'when query errors result is not blank' do
+    let(:goal) { { kind: 'last_query_fails' } }
+    let(:query) { 'foo()' }
+
+    it { expect(result[2][:result]).to include 'ReferenceError: foo is not defined' }
   end
 end

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -117,6 +117,8 @@ describe JavascriptTryHook do
     let(:goal) { { kind: 'last_query_fails' } }
     let(:query) { 'foo()' }
 
+    it { expect(result[1]).to eq :passed }
+    it { expect(result[2][:status]).to eq :failed }
     it { expect(result[2][:result]).to include 'ReferenceError: foo is not defined' }
   end
 end


### PR DESCRIPTION
# Goal :dart: 
Include query result even when query errors.

# Details :spiral_notepad: 
When query errors goal separator is never printed, which caused result parsing to fail.
~Current failing test does not seem to be related to this PR, but rather it's a dependency problem.~
Test was failing because of a syntax error, this behavior seems ok to me, but just to make sure... @flbulgarelli?

# Future work :rocket: 
~Fix failing test~
None.