### PR TITLE
Fix faulty interactive behaviour on errors

### DIFF
--- a/lib/try_hook.rb
+++ b/lib/try_hook.rb
@@ -29,17 +29,21 @@ js
   end
 
   def to_structured_results(_file, result, status)
-    query_result = result[/#{query_separator}\n\K.*?(?=\n#{goal_separator}|\z)/m]
     goal = result[/#{goal_separator}\n\K.*(?=\n)/m]
 
     {
-        query: to_query_result(query_result, status),
+        query: to_query_result(result, status),
         goal: goal,
         status: status
     }
   end
 
   def to_query_result(result, status)
-    { result: result, status: status }
+    case result
+    when /#{query_separator}\n(.*?)\n(#{goal_separator}|\z)/m
+      { result: $1, status: status }
+    else
+      { result: result, status: :errored }
+    end
   end
 end

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -113,12 +113,21 @@ describe JavascriptTryHook do
     end
   end
 
-  context 'when query errors result is not blank' do
+  context 'when query fails result is not blank' do
     let(:goal) { { kind: 'last_query_fails' } }
     let(:query) { 'foo()' }
 
     it { expect(result[1]).to eq :passed }
     it { expect(result[2][:status]).to eq :failed }
     it { expect(result[2][:result]).to include 'ReferenceError: foo is not defined' }
+  end
+
+  context 'when query errors result is not blank' do
+    let(:goal) { { kind: 'last_query_fails' } }
+    let(:query) { 'foo)' }
+
+    it { expect(result[1]).to eq :failed }
+    it { expect(result[2][:status]).to eq :errored }
+    it { expect(result[2][:result]).to include 'SyntaxError: Unexpected token )' }
   end
 end


### PR DESCRIPTION
## :dart: Goal
Fix faulty behaviour where queries would often come back with no response.

## :memo: Details
This PR introduces two fixes:
- Firstly, while [this PR](https://github.com/mumuki/mumuki-javascript-runner/pull/32) was aimed at solving the same error, it failed to account for syntax errors. When a file has a syntax error, it can not be run at all, meaning the query start separator was never printed, which caused the result to fail to parse again.
- Secondly, when file fails to run entirely (probably due to syntax errors, but including other errors I may have failed to account for), response status is set to errored to prevent this query from being added to the cookie, and thus preventing this errored from being carried over to later queries.

## :warning: Dependencies
None.

## :back: Backwards compatibility
100%