### PR TITLE
Issue#27 console prints results multiple times

### DIFF
--- a/lib/query_hook.rb
+++ b/lib/query_hook.rb
@@ -28,7 +28,10 @@ function mumukiConsolePrettyPrint(e) {
 
 #{r.content}
 
+const mumukiConsoleLog = console.log
+console.log = (...data) => {}
 #{compile_cookie(r.cookie)}
+console.log = mumukiConsoleLog
 javascript
   end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -199,4 +199,11 @@ SyntaxError: Unexpected token )` }
     it { expect(result[0]).to_not include '__mumuki_query_result__' }
     it { expect(result[1]).to eq :errored }
   end
+
+  context 'console log query with cookie' do
+    let(:request) { struct(query: 'console.log("foo")', cookie: ['console.log("bar")']) }
+    it { expect(result[0]).to include 'foo' }
+    it { expect(result[0]).to_not include 'bar' }
+    it { expect(result[1]).to eq :passed }
+  end
 end


### PR DESCRIPTION
## :dart: Goal
Stop query console logs from printing more than once through the request's cookie.

## :memo: Details
Mutes console around the lines carried over from the cookie to prevent `console.log` calls to be printed more than once.

Fixes #27.

## :warning: Dependencies
None.

## :back: Backwards compatibility
100%